### PR TITLE
Annotations driver inheritance chain

### DIFF
--- a/Driver/AnnotationsDriver.php
+++ b/Driver/AnnotationsDriver.php
@@ -25,20 +25,23 @@ class AnnotationsDriver implements MetadataDriverInterface
         $metadata = new FormMetadata();
 
         $reader = new \Doctrine\Common\Annotations\AnnotationReader();
+
         $reflectionClass = new \ReflectionClass(get_class($entity));
 
-        $properties = $reflectionClass->getProperties();
-        foreach($properties as $property) {
-            $field = $reader->getPropertyAnnotation($property, 'FlintLabs\Bundle\FormMetadataBundle\Configuration\Field');
-            if(!empty($field)) {
-                if(empty($field->name)) {
-                    $field->name = $property->getName();
+        while (is_object($reflectionClass)) {
+            $properties = $reflectionClass->getProperties();
+            foreach($properties as $property) {
+                $field = $reader->getPropertyAnnotation($property, 'FlintLabs\Bundle\FormMetadataBundle\Configuration\Field');
+                if(!empty($field)) {
+                    if(empty($field->name)) {
+                        $field->name = $property->getName();
+                    }
+                    $metadata->addField($field);
                 }
-                $metadata->addField($field);
             }
+            $reflectionClass = $reflectionClass->getParentClass();
         }
 
         return $metadata;
     }
-
 }


### PR DESCRIPTION
Changed the annotations driver so that it continues up the inheritance chain of the entity if there is one. This is helpful if you're using doctrine inheritance.
