### PR TITLE
Change to createFormBuilder method

### DIFF
--- a/FormMapper.php
+++ b/FormMapper.php
@@ -44,17 +44,17 @@ class FormMapper
      * @param $form
      * @return
      */
-    public function createFormBuilder($entity, $data = null, array $options = array())
+    public function createFormBuilder($data = null, array $options = array())
     {
         // Build the $form
         $formBuilder = $this->factory->createBuilder('form', $data, $options);
-        
+
         // Read the entity meta data and add to the form
         if(empty($this->drivers)) return $formBuilder;
 
         // Look to the readers to find metadata
         foreach ($this->drivers as $driver) {
-            $metadata = $driver->getMetadata($entity);
+            $metadata = $driver->getMetadata($data);
             if(!empty($metadata)) break;
         }
 


### PR DESCRIPTION
Changed the createFormBuilder method as I think it was wrong. The function definition should really match that of symfonys FrameworkBundle Controller (line 137). Passing the entity as the first argument now means the object you initially pass into the form gets updated, instead of having to call getData on the form.

``` php
<?php
$homepage = new HomePage();
$form = $this->get('form_metadata.mapper')->createFormBuilder($homepage)->getForm();
$request = $this->getRequest();
if ($request->getMethod() == 'POST') {
  $form->bindRequest($request);
    if ($form->isValid()) {
      die(var_dump($homepage)); // should be updated
    }
}
?>
```
