### PR TITLE
Fixed request.CRITICAL exception

### DIFF
--- a/Configuration/Field.php
+++ b/Configuration/Field.php
@@ -14,6 +14,7 @@ namespace FlintLabs\Bundle\FormMetadataBundle\Configuration;
  *
  * e.g. @Form\Field("text", foo="bar")
  *
+ * @Annotation
  * @author camm (camm@flintinteractive.com.au)
  */
 class Field extends \Doctrine\Common\Annotations\Annotation

--- a/Configuration/FieldGroup.php
+++ b/Configuration/FieldGroup.php
@@ -6,6 +6,8 @@
 
 /**
  * e.g. @Form\FieldGroup('example')
+ *
+ * @Annotation
  * @author camm (camm@flintinteractive.com.au)
  */
 class FieldGroup 


### PR DESCRIPTION
Without @Annotation annotation AnnotationException is thrown.

> Doctrine\Common\Annotations\AnnotationException: [Semantical Error] The class "FlintLabs\Bundle\FormMetadataBundle\Configuration\Field" is not annotated with @Annotation.
