### PR TITLE
+ @Annotation

### DIFF
--- a/Configuration/Field.php
+++ b/Configuration/Field.php
@@ -15,6 +15,7 @@ namespace FlintLabs\Bundle\FormMetadataBundle\Configuration;
  * e.g. @Form\Field("text", foo="bar")
  *
  * @author camm (camm@flintinteractive.com.au)
+ * @Annotation
  */
 class Field extends \Doctrine\Common\Annotations\Annotation
 {


### PR DESCRIPTION
Doctrine throw a semantical annotation exception without it.
